### PR TITLE
fix StoreAsyncMethod (await store operation),

### DIFF
--- a/src/IdentityServer4.MongoDB/DbContexts/PersistedGrantDbContext.cs
+++ b/src/IdentityServer4.MongoDB/DbContexts/PersistedGrantDbContext.cs
@@ -49,24 +49,19 @@ namespace IdentityServer4.MongoDB.DbContexts
             get { return _persistedGrants.AsQueryable(); }
         }
 
-        public async Task Update(Expression<Func<PersistedGrant, bool>> filter, PersistedGrant entity)
+        public Task Remove(Expression<Func<PersistedGrant, bool>> filter)
         {
-            await _persistedGrants.ReplaceOneAsync(filter, entity);
+            return _persistedGrants.DeleteManyAsync(filter);
         }
 
-        public async Task Add(PersistedGrant entity)
+        public Task RemoveExpired()
         {
-            await _persistedGrants.InsertOneAsync(entity);
+            return Remove(x => x.Expiration < DateTime.UtcNow);
         }
 
-        public async Task Remove(Expression<Func<PersistedGrant, bool>> filter)
+        public Task InsertOrUpdate(Expression<Func<PersistedGrant, bool>> filter, PersistedGrant entity)
         {
-            await _persistedGrants.DeleteManyAsync(filter);
-        }
-
-        public async Task RemoveExpired()
-        {
-            await Remove(x => x.Expiration < DateTime.UtcNow);
+            return _persistedGrants.ReplaceOneAsync(filter, entity, new UpdateOptions() {IsUpsert = true});
         }
     }
 }

--- a/src/IdentityServer4.MongoDB/Entities/PersistedGrant.cs
+++ b/src/IdentityServer4.MongoDB/Entities/PersistedGrant.cs
@@ -8,7 +8,7 @@ namespace IdentityServer4.MongoDB.Entities
 {
     public class PersistedGrant
     {
-        public ObjectId Id { get; set; }
+        //public ObjectId Id { get; set; }
         public string Key { get; set; }
         public string Type { get; set; }
         public string SubjectId { get; set; }

--- a/src/IdentityServer4.MongoDB/Interfaces/IPersistedGrantDbContext.cs
+++ b/src/IdentityServer4.MongoDB/Interfaces/IPersistedGrantDbContext.cs
@@ -13,12 +13,10 @@ namespace IdentityServer4.MongoDB.Interfaces
     {
         IQueryable<PersistedGrant> PersistedGrants { get; }
 
-        Task Add(PersistedGrant entity);
-
-        Task Update(Expression<Func<PersistedGrant, bool>> filter, PersistedGrant entity);
-
         Task Remove(Expression<Func<PersistedGrant, bool>> filter);
 
         Task RemoveExpired();
+
+        Task InsertOrUpdate(Expression<Func<PersistedGrant, bool>> filter, PersistedGrant entity);
     }
 }

--- a/src/IdentityServer4.MongoDB/Stores/PersistedGrantStore.cs
+++ b/src/IdentityServer4.MongoDB/Stores/PersistedGrantStore.cs
@@ -25,32 +25,19 @@ namespace IdentityServer4.MongoDB.Stores
             _logger = logger;
         }
 
-        public Task StoreAsync(PersistedGrant token)
+        public async Task StoreAsync(PersistedGrant token)
         {
             try
             {
-                var existing = _context.PersistedGrants.SingleOrDefault(x => x.Key == token.Key);
-                if (existing == null)
-                {
-                    _logger.LogDebug("{persistedGrantKey} not found in database", token.Key);
-
-                    var persistedGrant = token.ToEntity();
-                    _context.Add(persistedGrant);
-                }
-                else
-                {
-                    _logger.LogDebug("{persistedGrantKey} found in database", token.Key);
-
-                    token.UpdateEntity(existing);
-                    _context.Update(x => x.Key == token.Key, existing);
-                }
+                _logger.LogDebug("Try to save or update {persistedGrantKey} in database", token.Key);
+                await _context.InsertOrUpdate(t => t.Key == token.Key, token.ToEntity());
+                _logger.LogDebug("{persistedGrantKey} stored in database", token.Key);
             }
             catch (Exception ex)
             {
                 _logger.LogError(0, ex, "Exception storing persisted grant");
+                throw;
             }
-
-            return Task.FromResult(0);
         }
 
         public Task<PersistedGrant> GetAsync(string key)


### PR DESCRIPTION
Hello, guys!
I faced some problems with your library:
1. My Mongo went down but Identity server worked as usual and I didn't noticed this problem quickly, cause you catch all exceptions in StoreAsync method in PersistedGrantDbContext.
2. If client sends a lot of serial requests for refresh token, it can happen that new token ins't stored in Mongo and client receives invalid_grant, cause in  StoreAsync method context operations aren't awaited.

So, I've made a pull request to fix this.
Thanks!