### PR TITLE
create MongoClient based on complete MongoClientSettings

### DIFF
--- a/src/IdentityServer4.MongoDB/DbContexts/MongoDBContextBase.cs
+++ b/src/IdentityServer4.MongoDB/DbContexts/MongoDBContextBase.cs
@@ -32,7 +32,7 @@ namespace IdentityServer4.MongoDB.DbContexts
                 clientSettings.UseSsl = false;
             }
 
-            _client = new MongoClient(settings.Value.ConnectionString);
+            _client = new MongoClient(clientSettings);
             Database = _client.GetDatabase(settings.Value.Database);
         }
 


### PR DESCRIPTION
Faced with the issue that the connector ignores my SslSettings that I passed during the configuration. For example I set `SslSettings.ServerCertificateValidationCallback` but it's never call. This is because the SslSettings never come to MongoClient.
The solution is quite simple: use MongoClient constructor that accept not just connection string, but the complete MongoClientSettings.