### PR TITLE
WIP - !!Breaking Change!! - #29 API scope mapping

### DIFF
--- a/IdentityServer4.MongoDB.sln
+++ b/IdentityServer4.MongoDB.sln
@@ -14,6 +14,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Host", "src\Host\Host.cspro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IdentityServer4.MongoDB", "src\IdentityServer4.MongoDB\IdentityServer4.MongoDB.csproj", "{A3A275B3-6017-4C98-B1E3-451EE07EF4F4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{CFAC3A63-E145-473E-9AA0-99EA17EC757D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IdentityServer4.Tests.MongoDB", "test\IdentityServer4.Tests.MongoDB\IdentityServer4.Tests.MongoDB.csproj", "{277D3533-13CC-462E-9BA0-74BAF2658D07}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +32,10 @@ Global
 		{A3A275B3-6017-4C98-B1E3-451EE07EF4F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A3A275B3-6017-4C98-B1E3-451EE07EF4F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3A275B3-6017-4C98-B1E3-451EE07EF4F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{277D3533-13CC-462E-9BA0-74BAF2658D07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{277D3533-13CC-462E-9BA0-74BAF2658D07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{277D3533-13CC-462E-9BA0-74BAF2658D07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{277D3533-13CC-462E-9BA0-74BAF2658D07}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -35,5 +43,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{00F607AE-4853-42A1-B536-F3B7759E1987} = {1E3859B1-7876-4B22-B7B6-1049D0344E52}
 		{A3A275B3-6017-4C98-B1E3-451EE07EF4F4} = {1E3859B1-7876-4B22-B7B6-1049D0344E52}
+		{277D3533-13CC-462E-9BA0-74BAF2658D07} = {CFAC3A63-E145-473E-9AA0-99EA17EC757D}
 	EndGlobalSection
 EndGlobal

--- a/src/IdentityServer4.MongoDB/DbContexts/ConfigurationDbContext.cs
+++ b/src/IdentityServer4.MongoDB/DbContexts/ConfigurationDbContext.cs
@@ -16,6 +16,7 @@ namespace IdentityServer4.MongoDB.DbContexts
         private readonly IMongoCollection<Client> _clients;
         private readonly IMongoCollection<IdentityResource> _identityResources;
         private readonly IMongoCollection<ApiResource> _apiResources;
+        private readonly IMongoCollection<ApiScope> _apiScopes;
 
         public ConfigurationDbContext(IOptions<MongoDBConfiguration> settings)
             : base(settings)
@@ -23,10 +24,12 @@ namespace IdentityServer4.MongoDB.DbContexts
             _clients = Database.GetCollection<Client>(Constants.TableNames.Client);
             _identityResources = Database.GetCollection<IdentityResource>(Constants.TableNames.IdentityResource);
             _apiResources = Database.GetCollection<ApiResource>(Constants.TableNames.ApiResource);
+            _apiScopes = Database.GetCollection<ApiScope>(Constants.TableNames.ApiScope);
 
             CreateClientsIndexes();
             CreateIdentityResourcesIndexes();
             CreateApiResourcesIndexes();
+            CreateApiScopesIndexes();
         }
 
         private void CreateClientsIndexes()
@@ -58,6 +61,15 @@ namespace IdentityServer4.MongoDB.DbContexts
             _apiResources.Indexes.CreateOne(scopesIndexModel);
         }
 
+        private void CreateApiScopesIndexes()
+        {
+            var indexOptions = new CreateIndexOptions { Background = true };
+
+            var builder = Builders<ApiScope>.IndexKeys;
+            var nameIndexModel = new CreateIndexModel<ApiScope>(builder.Ascending(_ => _.Name), indexOptions);
+            _apiScopes.Indexes.CreateOne(nameIndexModel);
+        }
+
         public IQueryable<Client> Clients
         {
             get { return _clients.AsQueryable(); }
@@ -73,6 +85,8 @@ namespace IdentityServer4.MongoDB.DbContexts
             get { return _apiResources.AsQueryable(); }
         }
 
+        public IQueryable<ApiScope> ApiScopes => this._apiScopes.AsQueryable();
+
         public async Task AddClient(Client entity)
         {
             await _clients.InsertOneAsync(entity);
@@ -86,6 +100,11 @@ namespace IdentityServer4.MongoDB.DbContexts
         public async Task AddApiResource(ApiResource entity)
         {
             await _apiResources.InsertOneAsync(entity);
+        }
+
+        public async Task AddApiScope(ApiScope entity)
+        {
+            await this._apiScopes.InsertOneAsync(entity);
         }
     }
 }

--- a/src/IdentityServer4.MongoDB/Entities/ApiResource.cs
+++ b/src/IdentityServer4.MongoDB/Entities/ApiResource.cs
@@ -14,7 +14,7 @@ namespace IdentityServer4.MongoDB.Entities
         public IDictionary<string, string> Properties { get; set; }
 
         public List<ApiSecret> Secrets { get; set; }
-        public List<ApiScope> Scopes { get; set; }
+        public List<string> Scopes { get; set; }
         public List<ApiResourceClaim> UserClaims { get; set; }
     }
 }

--- a/src/IdentityServer4.MongoDB/IdentityServer4.MongoDB.csproj
+++ b/src/IdentityServer4.MongoDB/IdentityServer4.MongoDB.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Version>3.1.0</Version>
+    <Version>3.1.0-preview.1</Version>
     <PackageReleaseNotes>Migration to .NET Core 3.1</PackageReleaseNotes>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyVersion>3.1.0.0</AssemblyVersion>

--- a/src/IdentityServer4.MongoDB/Interfaces/IConfigurationDbContext.cs
+++ b/src/IdentityServer4.MongoDB/Interfaces/IConfigurationDbContext.cs
@@ -14,11 +14,14 @@ namespace IdentityServer4.MongoDB.Interfaces
         IQueryable<Client> Clients { get; }
         IQueryable<IdentityResource> IdentityResources { get; }
         IQueryable<ApiResource> ApiResources { get; }
+        IQueryable<ApiScope> ApiScopes { get; }
 
         Task AddClient(Client entity);
 
         Task AddIdentityResource(IdentityResource entity);
 
         Task AddApiResource(ApiResource entity);
+
+        Task AddApiScope(ApiScope entity);
     }
 }

--- a/src/IdentityServer4.MongoDB/Stores/ResourceStore.cs
+++ b/src/IdentityServer4.MongoDB/Stores/ResourceStore.cs
@@ -40,10 +40,7 @@ namespace IdentityServer4.MongoDB.Stores
         public Task<IEnumerable<ApiScope>> FindApiScopesByNameAsync(IEnumerable<string> scopeNames)
         {
             var names = scopeNames.ToArray();
-            var apis = _context.ApiResources.SelectMany(x => x.Scopes).Where(x => names.Contains(x.Name));
-
-            var results = apis.ToArray();
-            var models = results.Select(x => x.ToModel()).ToArray();
+            var models = _context.ApiScopes.Where(x => names.Contains(x.Name)).Select(x => x.ToModel());
 
             _logger.LogDebug("Found {scopes} API scopes in database", models.Select(x => x.Name));
 
@@ -55,7 +52,7 @@ namespace IdentityServer4.MongoDB.Stores
         {
             var names = scopeNames.ToArray();
 
-            var apis = _context.ApiResources.Where(x => x.Scopes.Any(y => names.Contains(y.Name)));
+            var apis = _context.ApiResources.Where(x => x.Scopes.Any(y => names.Contains(y)));
 
             var results = apis.ToArray();
             var models = results.Select(x => x.ToModel()).ToArray();
@@ -84,7 +81,7 @@ namespace IdentityServer4.MongoDB.Stores
 
             var apis = _context.ApiResources;
 
-            var scopes = _context.ApiResources.SelectMany(x => x.Scopes);
+            var scopes = _context.ApiScopes;
 
             var result = new Resources(
                 identity.ToArray().Select(x => x.ToModel()).AsEnumerable(),

--- a/test/IdentityServer4.Tests.MongoDB/IdentityServer4.Tests.MongoDB.csproj
+++ b/test/IdentityServer4.Tests.MongoDB/IdentityServer4.Tests.MongoDB.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\IdentityServer4.MongoDB\IdentityServer4.MongoDB.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/IdentityServer4.Tests.MongoDB/Mappers/ApiResourceMappersTest.cs
+++ b/test/IdentityServer4.Tests.MongoDB/Mappers/ApiResourceMappersTest.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using IdentityServer4.MongoDB.Entities;
+using IdentityServer4.MongoDB.Mappers;
+using Xunit;
+
+namespace IdentityServer4.Tests.MongoDB.Mappers
+{
+    
+    public class ApiResourceMappersTest
+    {
+
+        [Fact]
+        public void ToEntity_UsingStringsAsScopes_MapsCorrectly()
+        {
+            var toBeMapped = new Models.ApiResource("test-resource", "Test Resource") {
+                Scopes = {"test", "test.scope1", "test.scope2"}
+            };
+
+            var mappedEntity = toBeMapped.ToEntity();
+            
+            Assert.Collection(
+                mappedEntity.Scopes,
+                scope => Assert.Equal("test", scope),
+                scope => Assert.Equal("test.scope1", scope),
+                scope => Assert.Equal("test.scope2", scope)
+            );
+        }
+
+        [Fact]
+        public void ToModel_UsingStringsAsScopes_MapsCorrectly()
+        {
+            var toBeMapped = new ApiResource {
+                Name = "my-api",
+                DisplayName = "My API",
+                Scopes = new List<string> { "api", "api.scope1", "api.scope2" }
+            };
+
+            var mappedModel = toBeMapped.ToModel();
+            
+            Assert.Collection(
+                mappedModel.Scopes,
+                scope => Assert.Equal("api", scope),
+                scope => Assert.Equal("api.scope1", scope),
+                scope => Assert.Equal("api.scope2", scope)
+            );
+        }
+    }
+}


### PR DESCRIPTION
As of IdentityServer v4.0.0 API scopes in the API resource model are now stored as strings. This commit reflects that change in the API resource entity.

- Introduce ApiScopes to IConfigurationDbContext and implementations
- Use new ApiScopes collection in ResourceStore.FindApiScopesByNameAsync
- Change type of ApiResource.Scopes to List<string>

**Further notices**

I've tested a package built from this with my freshly set up project and it worked. It's nothing very sophisticated, so maybe someone has an other project to test this with. As such, I'm not sure, whether the changes are sufficient.

Nevertheless, as this is a breaking change, I suggest to add some document which explains how to update from v2.x to the new version. Migration of data will be necessary. I've seen projects handling this in a UPDATE.md living at project root.

I've also added a test project containing two simple unit tests that secure the new functionality. I guess it's basically a good idea to have some tests and it could be built on in the future.