### PR TITLE
Issue #34 Fixes NotSupportedException when loading ApiScopes by name

### DIFF
--- a/src/IdentityServer4.MongoDB/IdentityServer4.MongoDB.csproj
+++ b/src/IdentityServer4.MongoDB/IdentityServer4.MongoDB.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>MongoDB persistence layer for IdentityServer4</Description>
-    <VersionPrefix>4.0.0-rc.1</VersionPrefix>
+    <VersionPrefix>4.0.0-rc.2</VersionPrefix>
     <Authors>Diogo Damiani</Authors>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <AssemblyName>IdentityServer4.Contrib.MongoDB</AssemblyName>
@@ -15,7 +15,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Version>4.0.0-rc.1</Version>
+    <Version>4.0.0-rc.2</Version>
     <PackageReleaseNotes>Migration to .NET Core 3.1 and IdentityServer 4.0</PackageReleaseNotes>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>

--- a/src/IdentityServer4.MongoDB/Stores/ResourceStore.cs
+++ b/src/IdentityServer4.MongoDB/Stores/ResourceStore.cs
@@ -40,7 +40,11 @@ namespace IdentityServer4.MongoDB.Stores
         public Task<IEnumerable<ApiScope>> FindApiScopesByNameAsync(IEnumerable<string> scopeNames)
         {
             var names = scopeNames.ToArray();
-            var models = _context.ApiScopes.Where(x => names.Contains(x.Name)).Select(x => x.ToModel());
+            var models = _context.ApiScopes
+                .Where(x => names.Contains(x.Name))
+                .ToArray()
+                .Select(x => x.ToModel())
+                .ToArray();
 
             _logger.LogDebug("Found {scopes} API scopes in database", models.Select(x => x.Name));
 


### PR DESCRIPTION
`ResourceStore.FindApiScopesByNameAsync` would throw a `NotSupportedException`, because a `Select(x => x.ToModel())` is executed on MongoDB's IQueryable implementation, while `ToModel` is not a queryable part of the given Entity, but an external extension method.

This fix changes this behaviour by collecting the query result into an array and then performing the `Select` just like the other query methods do with their queries.