### PR TITLE
Fix MongoDB SSL configuration when no SSL settings are specified

### DIFF
--- a/src/IdentityServer4.MongoDB/DbContexts/MongoDBContextBase.cs
+++ b/src/IdentityServer4.MongoDB/DbContexts/MongoDBContextBase.cs
@@ -24,7 +24,7 @@ namespace IdentityServer4.MongoDB.DbContexts
 
             var clientSettings = MongoClientSettings.FromUrl(mongoUrl);
 
-            if (clientSettings.SslSettings != null)
+            if (settings.Value.SslSettings != null)
             {
                 clientSettings.SslSettings = settings.Value.SslSettings;
                 clientSettings.UseTls = true;


### PR DESCRIPTION
There is a mistake in MongoDB configuration code - `clientSettings` will always be non-null, since it has a default value from `MongoClientSettings.FromUrl`. Therefore it is currently impossible to connect to a Mongo instance which is not using TLS/SSL. This PR fixes the logic which checks for SSL configuration.